### PR TITLE
CODECRAFT-94 named mutex for posix

### DIFF
--- a/code/memory-mgr/include/memory-mgr/config/platform/apple.h
+++ b/code/memory-mgr/include/memory-mgr/config/platform/apple.h
@@ -25,137 +25,30 @@ Please feel free to contact me via e-mail: shikin@users.sourceforge.net
 
 #define MGR_APPLE_PLATFORM
 
-#include <fcntl.h>  //O_CREAT, O_*...
-#include <libproc.h>
 #include "memory-mgr/detail/temp_buffer.h"
-#include "memory-mgr/detail/types.h"
-#include <pthread.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sys/mman.h>  //shm_xxx
-#include <sys/stat.h>  //mode_t, S_IRWXG, S_IRWXO, S_IRWXU,
-#include <sys/syslimits.h>
-#include <unistd.h>  //ftruncate, close
 
-#include <semaphore.h>
+#include "memory-mgr/config/platform/posix.h"
 
-#include <string>
-#include <mutex>
-#include <algorithm>
-#include <boost/interprocess/sync/named_recursive_mutex.hpp>
+#include <libproc.h>
+#include <sys/proc_info.h>
 
 namespace memory_mgr
 {
 namespace osapi
 {
-typedef pthread_mutex_t critical_section;
-
-typedef int file_handle_t;
-typedef file_handle_t mapping_handle_t;
-typedef ::mode_t mode_t;
-static const mapping_handle_t invalid_mapping_handle = -1;
-static void* invalid_mapping_address = MAP_FAILED;
-
-static inline void initialize_critical_section(critical_section* cs)
-{
-  pthread_mutexattr_t mutexattr = {};   // Mutex attribute variable
-
-  pthread_mutexattr_init(&mutexattr);
-  // Set the mutex as a recursive mutex
-  pthread_mutexattr_settype(&mutexattr, PTHREAD_MUTEX_RECURSIVE);
-  pthread_mutex_init(cs, &mutexattr);
-  // After initializing the mutex, the thread attribute can be destroyed
-  pthread_mutexattr_destroy(&mutexattr);
-}
-
-static inline void delete_critical_section(critical_section* cs) { pthread_mutex_destroy(cs); }
-
-static inline void enter_critical_section(critical_section* cs) { pthread_mutex_lock(cs); }
-
-static inline void leave_critical_section(critical_section* cs) { pthread_mutex_unlock(cs); }
-
-static inline int close_handle(file_handle_t handle) { return ::close(handle); }
-
-static inline mapping_handle_t create_file_mapping(const std::string& name, int open_flag, mode_t access_mode, size_t /*size*/)
-{
-  return shm_open(name.c_str(), open_flag, access_mode);
-}
-
-static inline int resize_file_mapping(mapping_handle_t mapping, size_t size) { return ftruncate(mapping, size); }
-
-static inline void* map_view_of_file(mapping_handle_t handle, int file_protect, std::size_t numbytes, int flags = MAP_SHARED, off_t offset = 0, void* base_addr = 0)
-{
-  return mmap(base_addr, numbytes, file_protect, flags, handle, offset);
-}
-
-static inline int unmap_view_of_file(void* address, size_t size) { return munmap(address, size); }
-
-static inline int close_file_mapping(const std::string& name, mapping_handle_t mapping)
-{
-  shm_unlink(name.c_str());
-  return osapi::close_handle(mapping);
-}
-
-
-using mutex_handle_t = sem_t*;
-
-namespace detail
-{
-  static inline std::string process_name(std::string name)
-  {
-    std::replace(name.begin(), name.end(), ' ', '_');
-    return "/" + name;
-  }
-}
-
-static inline mutex_handle_t create_mutex(const std::string& name )
-{
-  mutex_handle_t mutex = sem_open(detail::process_name(name).c_str(), O_CREAT, 0644, 1);
-  if (mutex == SEM_FAILED) {
-    throw std::runtime_error("sem_open failed");
-  }
-  return mutex;
-}
-
-static inline bool release_mutex(mutex_handle_t mutex)
-{
-  // The last use should call sem_unlink, but current model of doesn't allow it
-  return sem_close(mutex) != -1;
-}
-
-enum lock_status{ lock_aquired, lock_abandoned, lock_timeout, lock_failed };
-
-
-static inline lock_status lock_mutex( mutex_handle_t mutex )
-{
-  if (sem_wait(mutex) == -1) {
-    return lock_failed;
-  }
-  return lock_aquired;
-}
-
-static inline bool unlock_mutex( mutex_handle_t mutex )
-{
-  return sem_post(mutex) != -1;
-}
-
 static inline std::string get_executable_path()
 {
-  int ret;
-  pid_t pid;
-  char pathbuf[PROC_PIDPATHINFO_MAXSIZE];
+  detail::char_buffer pathbuf(PROC_PIDPATHINFO_MAXSIZE);
 
-  pid = getpid();
-  ret = proc_pidpath(pid, pathbuf, sizeof(pathbuf));
+  const pid_t pid = getpid();
+  const int ret = proc_pidpath(pid, pathbuf, pathbuf.count());
   if (ret <= 0)
   {
-    return std::string();
+    return {};
   }
   else
   {
-    // printf("proc %d: %s\n", pid, pathbuf);
-    return std::string(pathbuf);
+    return pathbuf.get();
   }
 }
 }  // namespace osapi

--- a/code/memory-mgr/include/memory-mgr/config/platform/linux.h
+++ b/code/memory-mgr/include/memory-mgr/config/platform/linux.h
@@ -115,9 +115,18 @@ namespace memory_mgr
 
 		using mutex_handle_t = sem_t*;
 
+		namespace detail
+		{
+			static inline std::string process_name(std::string name)
+			{
+				std::replace(name.begin(), name.end(), ' ', '_');
+				return "/" + name;
+			}
+		}
+
 		static inline mutex_handle_t create_mutex(const std::string& name )
 		{
-			mutex_handle_t mutex = sem_open(("/" + name).c_str(), O_CREAT, 0644, 1);
+			mutex_handle_t mutex = sem_open(detail::process_name(name).c_str(), O_CREAT, 0644, 1);
 			if (mutex == SEM_FAILED) {
 				throw std::runtime_error("sem_open failed");
 			}

--- a/code/memory-mgr/include/memory-mgr/config/platform/linux.h
+++ b/code/memory-mgr/include/memory-mgr/config/platform/linux.h
@@ -1,4 +1,4 @@
-/* 
+/*
 Generic Memory Manager (memory-mgr)
 http://memory-mgr.sourceforge.net/
 Copyright (c) 2007-2008 Anton (shikin) Matosov
@@ -25,155 +25,44 @@ Please feel free to contact me via e-mail: shikin@users.sourceforge.net
 
 #define MGR_LINUX_PLATFORM
 
-#include <pthread.h>
-
-#include <fcntl.h>		//O_CREAT, O_*... 
-#include <sys/mman.h>	//shm_xxx
-#include <unistd.h>		//ftruncate, close
-#include <sys/stat.h>	//mode_t, S_IRWXG, S_IRWXO, S_IRWXU,
-
-#include <sstream>
-#include <iostream>
-#include <mutex>
-#include <algorithm>
-
-#include <semaphore.h>
+#include "memory-mgr/config/platform/posix.h"
 
 #include "memory-mgr/detail/temp_buffer.h"
 #include "memory-mgr/detail/types.h"
 
+#include <sstream>
+
 namespace memory_mgr
 {
-	namespace detail
-	{
-		static inline std::string process_name(std::string name)
-		{
-			std::replace(name.begin(), name.end(), ' ', '_');
-			return "/" + name;
-		}
-	}
-	namespace osapi
-	{
-		typedef pthread_mutex_t critical_section;
+namespace osapi
+{
+static inline std::string get_executable_path()
+{
+  /*
+  Linux:
+  /proc/<pid>/exe
 
-		typedef int				file_handle_t;
-		typedef file_handle_t	mapping_handle_t;
-		typedef ::mode_t		mode_t;
-		static const mapping_handle_t invalid_mapping_handle = -1;
-		static void* invalid_mapping_address = MAP_FAILED;
+  Solaris:
+  /proc/<pid>/object/a.out (filename only)
+  /proc/<pid>/path/a.out (complete pathname)
 
-		static inline void initialize_critical_section( critical_section* cs )
-		{
-			pthread_mutexattr_t mutexattr = {};   // Mutex attribute variable
+  *BSD (and maybe Darwing too):
+  /proc/<pid>/file
+  */
 
-			pthread_mutexattr_init(&mutexattr);
-			// Set the mutex as a recursive mutex
-			pthread_mutexattr_settype(&mutexattr, PTHREAD_MUTEX_RECURSIVE);
-			pthread_mutex_init( cs, &mutexattr );
-			//After initializing the mutex, the thread attribute can be destroyed
-			pthread_mutexattr_destroy(&mutexattr);
-		}
-
-		static inline void delete_critical_section( critical_section* cs )
-		{
-			pthread_mutex_destroy( cs );
-		}
-
-		static inline void enter_critical_section( critical_section* cs )
-		{
-			pthread_mutex_lock( cs );
-		}
-
-		static inline void leave_critical_section( critical_section* cs )
-		{
-			pthread_mutex_unlock( cs );
-		}
-
-		static inline int close_handle(file_handle_t handle)
-		{
-			return ::close(handle);
-		}
-
-		static inline mapping_handle_t create_file_mapping( const std::string& name,
-			int open_flag, mode_t access_mode, size_t /*size*/ )
-		{
-			return shm_open( name.c_str(), open_flag, access_mode );
-		}
-
-		static inline int resize_file_mapping(mapping_handle_t mapping,
-			size_t size)
-		{
-			return ftruncate( mapping, size );
-		}
-
-		static inline void* map_view_of_file(mapping_handle_t handle, int file_protect, std::size_t numbytes, int flags = MAP_SHARED, off_t offset = 0, void *base_addr = 0 )
-		{  
-			return mmap(base_addr, numbytes, file_protect, flags, handle, offset);
-		} 
-
-		static inline int unmap_view_of_file(void* address, size_t size)
-		{
-			return munmap( address, size );
-		}
-
-		static inline int close_file_mapping(const std::string& name, mapping_handle_t mapping)
-		{
-			shm_unlink( name.c_str() );
-			return osapi::close_handle( mapping );
-		}
-
-		using mutex_handle_t = sem_t*;
-
-		static inline mutex_handle_t create_mutex(const std::string& name )
-		{
-			mutex_handle_t mutex = sem_open(detail::process_name(name).c_str(), O_CREAT, 0644, 1);
-			if (mutex == SEM_FAILED) {
-				throw std::runtime_error("sem_open failed");
-			}
-			return mutex;
-		}
-
-		static inline bool release_mutex(mutex_handle_t mutex)
-		{
-			return sem_close(mutex) != -1;
-		}
-
-		enum lock_status{ lock_aquired, lock_abandoned, lock_timeout, lock_failed };
-
-
-		static inline lock_status lock_mutex( mutex_handle_t mutex )
-		{
-			if (sem_wait(mutex) == -1) {
-				return lock_failed;
-			}
-			return lock_aquired;
-		}
-
-		static inline bool unlock_mutex( mutex_handle_t mutex )
-		{
-			return sem_post(mutex) != -1;
-		}
-
-		static inline std::string get_executable_path()
-		{
-			/*
-			Linux:
-			/proc/<pid>/exe
-
-			Solaris:
-			/proc/<pid>/object/a.out (filename only)
-			/proc/<pid>/path/a.out (complete pathname)
-
-			*BSD (and maybe Darwing too):
-			/proc/<pid>/file
-			*/
-
-			detail::char_buffer path( 512 );
-			std::stringstream link;
-			link << "/proc/" << getpid() << "/exe";
-			readlink( link.str().c_str(), path, path.count() );	
-			return path.get();
-		}
-	}
+  detail::char_buffer path(512);
+  std::stringstream link;
+  link << "/proc/" << getpid() << "/exe";
+  auto size = readlink(link.str().c_str(), path, path.count());
+  if (size == -1)
+  {
+    return {};
+  }
+  else
+  {
+    path[size] = 0;
+  }
+  return path.get();
 }
-
+}  // namespace osapi
+}  // namespace memory_mgr

--- a/code/memory-mgr/include/memory-mgr/config/platform/linux.h
+++ b/code/memory-mgr/include/memory-mgr/config/platform/linux.h
@@ -35,6 +35,7 @@ Please feel free to contact me via e-mail: shikin@users.sourceforge.net
 #include <sstream>
 #include <iostream>
 #include <mutex>
+#include <algorithm>
 
 #include <semaphore.h>
 
@@ -43,6 +44,14 @@ Please feel free to contact me via e-mail: shikin@users.sourceforge.net
 
 namespace memory_mgr
 {
+	namespace detail
+	{
+		static inline std::string process_name(std::string name)
+		{
+			std::replace(name.begin(), name.end(), ' ', '_');
+			return "/" + name;
+		}
+	}
 	namespace osapi
 	{
 		typedef pthread_mutex_t critical_section;
@@ -114,15 +123,6 @@ namespace memory_mgr
 		}
 
 		using mutex_handle_t = sem_t*;
-
-		namespace detail
-		{
-			static inline std::string process_name(std::string name)
-			{
-				std::replace(name.begin(), name.end(), ' ', '_');
-				return "/" + name;
-			}
-		}
 
 		static inline mutex_handle_t create_mutex(const std::string& name )
 		{

--- a/code/memory-mgr/include/memory-mgr/config/platform/linux.h
+++ b/code/memory-mgr/include/memory-mgr/config/platform/linux.h
@@ -68,7 +68,7 @@ namespace memory_mgr
 
 			pthread_mutexattr_init(&mutexattr);
 			// Set the mutex as a recursive mutex
-			pthread_mutexattr_settype(&mutexattr, PTHREAD_MUTEX_RECURSIVE_NP);
+			pthread_mutexattr_settype(&mutexattr, PTHREAD_MUTEX_RECURSIVE);
 			pthread_mutex_init( cs, &mutexattr );
 			//After initializing the mutex, the thread attribute can be destroyed
 			pthread_mutexattr_destroy(&mutexattr);

--- a/code/memory-mgr/include/memory-mgr/config/platform/posix.h
+++ b/code/memory-mgr/include/memory-mgr/config/platform/posix.h
@@ -1,0 +1,132 @@
+/*
+Generic Memory Manager (memory-mgr)
+http://memory-mgr.sourceforge.net/
+Copyright (c) 2007-2008 Anton (shikin) Matosov
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 3, 29 June 2007 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA <http://fsf.org/>
+
+
+Please feel free to contact me via e-mail: shikin@users.sourceforge.net
+*/
+
+#pragma once
+
+#include "memory-mgr/detail/types.h"
+
+#include <sys/mman.h>  //shm_xxx
+#include <sys/stat.h>  //mode_t, S_IRWXG, S_IRWXO, S_IRWXU,
+
+#include <algorithm>
+#include <fcntl.h>  //O_CREAT, O_*...
+#include <iostream>
+#include <mutex>
+#include <pthread.h>
+#include <semaphore.h>
+#include <unistd.h>  //ftruncate, close
+
+namespace memory_mgr
+{
+namespace detail
+{
+static inline std::string process_name(std::string name)
+{
+  std::replace(name.begin(), name.end(), ' ', '_');
+  return "/" + name;
+}
+}  // namespace detail
+namespace osapi
+{
+typedef pthread_mutex_t critical_section;
+
+typedef int file_handle_t;
+typedef file_handle_t mapping_handle_t;
+typedef ::mode_t mode_t;
+static const mapping_handle_t invalid_mapping_handle = -1;
+static void* invalid_mapping_address = MAP_FAILED;
+
+static inline void initialize_critical_section(critical_section* cs)
+{
+  pthread_mutexattr_t mutexattr = {};  // Mutex attribute variable
+
+  pthread_mutexattr_init(&mutexattr);
+  // Set the mutex as a recursive mutex
+  pthread_mutexattr_settype(&mutexattr, PTHREAD_MUTEX_RECURSIVE);
+  pthread_mutex_init(cs, &mutexattr);
+  // After initializing the mutex, the thread attribute can be destroyed
+  pthread_mutexattr_destroy(&mutexattr);
+}
+
+static inline void delete_critical_section(critical_section* cs) { pthread_mutex_destroy(cs); }
+
+static inline void enter_critical_section(critical_section* cs) { pthread_mutex_lock(cs); }
+
+static inline void leave_critical_section(critical_section* cs) { pthread_mutex_unlock(cs); }
+
+static inline int close_handle(file_handle_t handle) { return ::close(handle); }
+
+static inline mapping_handle_t create_file_mapping(const std::string& name, int open_flag, mode_t access_mode, size_t /*size*/)
+{
+  return shm_open(name.c_str(), open_flag, access_mode);
+}
+
+static inline int resize_file_mapping(mapping_handle_t mapping, size_t size) { return ftruncate(mapping, size); }
+
+static inline void* map_view_of_file(mapping_handle_t handle, int file_protect, std::size_t numbytes, int flags = MAP_SHARED, off_t offset = 0, void* base_addr = 0)
+{
+  return mmap(base_addr, numbytes, file_protect, flags, handle, offset);
+}
+
+static inline int unmap_view_of_file(void* address, size_t size) { return munmap(address, size); }
+
+static inline int close_file_mapping(const std::string& name, mapping_handle_t mapping)
+{
+  shm_unlink(name.c_str());
+  return osapi::close_handle(mapping);
+}
+
+using mutex_handle_t = sem_t*;
+
+static inline mutex_handle_t create_mutex(const std::string& name)
+{
+  mutex_handle_t mutex = sem_open(detail::process_name(name).c_str(), O_CREAT, 0644, 1);
+  if (mutex == SEM_FAILED)
+  {
+    throw std::runtime_error("sem_open failed");
+  }
+  return mutex;
+}
+
+static inline bool release_mutex(mutex_handle_t mutex) { return sem_close(mutex) != -1; }
+
+enum lock_status
+{
+  lock_aquired,
+  lock_abandoned,
+  lock_timeout,
+  lock_failed
+};
+
+static inline lock_status lock_mutex(mutex_handle_t mutex)
+{
+  if (sem_wait(mutex) == -1)
+  {
+    return lock_failed;
+  }
+  return lock_aquired;
+}
+
+static inline bool unlock_mutex(mutex_handle_t mutex) { return sem_post(mutex) != -1; }
+}  // namespace osapi
+}  // namespace memory_mgr

--- a/code/memory-mgr/include/memory-mgr/config/platform/win32.h
+++ b/code/memory-mgr/include/memory-mgr/config/platform/win32.h
@@ -165,14 +165,9 @@ namespace memory_mgr
 			return CreateMutexA( detail::null_sa(), false, detail::get_name( name ) );
 		}
 
-		static inline mutex_handle_t open_mutex(const std::string& name, ulong access )
-		{ 
-			return OpenMutexA( access, false, detail::get_name( name ) );
-		}
-
 		static inline bool release_mutex(mutex_handle_t handle)
-		{ 
-			return ReleaseMutex(handle) != 0;  
+		{
+			return ReleaseMutex(handle) != FALSE;
 		}
 
 		enum lock_status{ lock_aquired, lock_abandoned, lock_timeout, lock_failed };

--- a/code/memory-mgr/include/memory-mgr/sync/named_mutex.h
+++ b/code/memory-mgr/include/memory-mgr/sync/named_mutex.h
@@ -43,7 +43,7 @@ namespace memory_mgr
 			{ osapi::lock_mutex( m_mutex ); }
 
 			inline void leave() const
-			{ osapi::release_mutex( m_mutex ); }
+			{ osapi::unlock_mutex( m_mutex ); }
 		private:
 			mutable osapi::mutex_handle_t m_mutex;
 

--- a/code/memory-mgr/tests/unit_tests/test_managed_base.cpp
+++ b/code/memory-mgr/tests/unit_tests/test_managed_base.cpp
@@ -41,11 +41,7 @@ public:
 	}
 };
 
-BOOST_FIXTURE_TEST_SUITE( test_managed_base, managed_base_fixture
-#ifndef MGR_WINDOWS_PLATFORM
-, *boost::unit_test::disabled() /* Named mutex is not implemented for non windows platforms yet */
-#endif
-);
+BOOST_FIXTURE_TEST_SUITE(test_managed_base, managed_base_fixture);
 
 	BOOST_AUTO_TEST_CASE( test_null_ptr )
 	{

--- a/code/memory-mgr/tests/unit_tests/test_offset_pointer.cpp
+++ b/code/memory-mgr/tests/unit_tests/test_offset_pointer.cpp
@@ -46,7 +46,7 @@ template class memory_mgr::offset_pointer< derived_test_class, ptr_mem_mgr >;
 
 BOOST_AUTO_TEST_SUITE( test_offset_pointer 
 #ifndef MGR_WINDOWS_PLATFORM
-, *boost::unit_test::disabled() /* Named mutex is not implemented for non windows platforms yet */
+// , *boost::unit_test::disabled() /* Named mutex is not implemented for non windows platforms yet */
 #endif
 )
 	

--- a/code/memory-mgr/tests/unit_tests/test_offset_pointer.cpp
+++ b/code/memory-mgr/tests/unit_tests/test_offset_pointer.cpp
@@ -44,11 +44,7 @@ template class memory_mgr::offset_pointer< builtin_type, ptr_mem_mgr >;
 template class memory_mgr::offset_pointer< base_test_class, ptr_mem_mgr >;
 template class memory_mgr::offset_pointer< derived_test_class, ptr_mem_mgr >;
 
-BOOST_AUTO_TEST_SUITE( test_offset_pointer 
-#ifndef MGR_WINDOWS_PLATFORM
-// , *boost::unit_test::disabled() /* Named mutex is not implemented for non windows platforms yet */
-#endif
-)
+BOOST_AUTO_TEST_SUITE(test_offset_pointer)
 	
 	typedef memory_mgr::offset_ptr< builtin_type > builtin_ptr;
 	typedef memory_mgr::offset_ptr< base_test_class > base_class_ptr;


### PR DESCRIPTION
Implement named mutex for linux and apple
Move out shared posix code to `posix.h`
Fix named_mutex to call unlock instead of release. 🤔 how did this work on windows?

Rework get_executable_path() for apple using `char_buffer`