### PR TITLE
CODECRAFT-35 fix shared segment issues on macOS

### DIFF
--- a/code/memory-mgr/include/memory-mgr/config/platform/win32.h
+++ b/code/memory-mgr/include/memory-mgr/config/platform/win32.h
@@ -83,6 +83,8 @@ namespace memory_mgr
 			}
 		}
 
+		static inline DWORD get_error_code() { return ::GetLastError(); }
+
 		static inline void initialize_critical_section( critical_section* cs )
 		{
 			return InitializeCriticalSection( cs );

--- a/code/memory-mgr/include/memory-mgr/shared_segment.h
+++ b/code/memory-mgr/include/memory-mgr/shared_segment.h
@@ -73,23 +73,19 @@ namespace memory_mgr
 					this->get_access_mode(), this->m_size );
 				if( this->m_mapping == osapi::invalid_mapping_handle )
 				{
-						std::stringstream ss;
-						ss << "file mapping creation failed. name: " << this->m_name << ". error: " << errno;
-						throw std::runtime_error( ss.str() );
+					const auto lastError = osapi::get_error_code();
+					std::stringstream ss;
+					ss << "file mapping creation failed. name: " << this->m_name << ". error: " << lastError;
+					throw std::runtime_error( ss.str() );
 				}
 
 				//Resize file mapping
 				if ( osapi::resize_file_mapping( this->m_mapping, this->m_size ) != 0 )
 				{
-					// Shared segment can be resized only upon creation,
-					// if it was resized before, attempting to change size will error and set errno to EINVAL
-					constexpr int kSecondResizeWillFail = EINVAL;
-					if (errno != kSecondResizeWillFail)
-					{
-						std::stringstream ss;
-						ss << "failed to resize file mapping. error " << errno;
-						throw std::runtime_error( ss.str() );
-					}
+					const auto lastError = osapi::get_error_code();
+					std::stringstream ss;
+					ss << "failed to resize file mapping. name: " << this->m_name << ". error: " << lastError;
+					throw std::runtime_error( ss.str() );
 				}
 
 				//Map file to memory
@@ -98,7 +94,10 @@ namespace memory_mgr
 
 				if( this->m_base == osapi::invalid_mapping_address )
 				{
-					throw std::runtime_error( "memory mapping failed" );
+					const auto lastError = osapi::get_error_code();
+					std::stringstream ss;
+					ss << "memory mapping failed. name: " << this->m_name << ". error: " << lastError;
+					throw std::runtime_error( ss.str() );
 				}
 			}
 		protected:

--- a/code/memory-mgr/include/memory-mgr/shared_segment.h
+++ b/code/memory-mgr/include/memory-mgr/shared_segment.h
@@ -73,7 +73,9 @@ namespace memory_mgr
 					this->get_access_mode(), this->m_size );
 				if( this->m_mapping == osapi::invalid_mapping_handle )
 				{
-					throw std::runtime_error( "file mapping creation failed" );
+						std::stringstream ss;
+						ss << "file mapping creation failed. name: " << this->m_name << ". error: " << errno;
+						throw std::runtime_error( ss.str() );
 				}
 
 				//Resize file mapping

--- a/code/memory-mgr/tests/unit_tests/test_named_objects.cpp
+++ b/code/memory-mgr/tests/unit_tests/test_named_objects.cpp
@@ -38,8 +38,8 @@ Please feel free to contact me via e-mail: shikin@users.sourceforge.net
 #include <boost/test/unit_test.hpp>
 #include <boost/mpl/list.hpp>
 
-MGR_DECLARE_SEGMENT_NAME( segmentName, "shared segment" );
-MGR_DECLARE_SEGMENT_NAME( segmentNameTracked, "tracked shared segment" );
+MGR_DECLARE_SEGMENT_NAME( segmentName, "sh-seg" );
+MGR_DECLARE_SEGMENT_NAME( segmentNameTracked, "tracked-seg" );
 
 typedef  memory_mgr::named_objects
 <
@@ -64,11 +64,7 @@ typedef  memory_mgr::named_objects
 MGR_DECLARE_MANAGER_CLASS( name_sz_shared_mgr, name_sz_shared_mgr_type );
 MGR_DECLARE_MANAGER_CLASS( name_shared_mgr, name_shared_mgr_type );
 
-BOOST_AUTO_TEST_SUITE( test_named_objects 
-#ifdef MGR_APPLE_PLATFORM
-, *boost::unit_test::disabled() /* Shared segment fails on macOS */
-#endif
-)
+BOOST_AUTO_TEST_SUITE(test_named_objects)
 
 	typedef boost::mpl::list< name_sz_shared_mgr, name_shared_mgr > managers_list;
 

--- a/code/memory-mgr/tests/unit_tests/test_shared_segment.cpp
+++ b/code/memory-mgr/tests/unit_tests/test_shared_segment.cpp
@@ -43,11 +43,7 @@ namespace
 
 template class memory_mgr::shared_segment< memmgr_type >;
 
-BOOST_AUTO_TEST_SUITE( test_shared_segment
-#ifdef MGR_APPLE_PLATFORM
-, *boost::unit_test::disabled() /* Shared segment fails on macOS */
-#endif
-)
+BOOST_AUTO_TEST_SUITE(test_shared_segment)
 
 	MGR_DECLARE_SEGMENT_NAME( test_segment, "test segment" );
 


### PR DESCRIPTION
Do not throw if shared segment resizing fails with EINVAL (22) as it occurs on posix if segment was already resized, e.g. if second process opens existing segment
Add error code to exceptions thrown upon shared segment creation
Fix shared segment name length, it is very limited on macOS (31 char according to [this stack overflow post](https://stackoverflow.com/questions/38049068/osx-shm-open-returns-enametoolong))