### PR TITLE
CODECRAFT-93 Update tests to use local memory segments

### DIFF
--- a/code/gstl/include/gstl/detail/helpers.hpp
+++ b/code/gstl/include/gstl/detail/helpers.hpp
@@ -32,16 +32,6 @@ namespace gstl
 	namespace helpers 
 	{
 		template<class StringT>
-		static inline StringT& add_leading_slash( StringT& str )
-		{
-			if(str[0] != '/')
-			{
-				str.insert( str.begin(), '/');
-			}
-			return str;
-		}
-
-		template<class StringT>
 		static inline StringT& add_trailing_slash( StringT& str )
 		{
 			if( str.length() >= 1 )

--- a/code/memory-mgr/include/memory-mgr/detail/helpers.h
+++ b/code/memory-mgr/include/memory-mgr/detail/helpers.h
@@ -40,16 +40,6 @@ static inline void throw_bad_alloc() { throw std::bad_alloc(); }
 static inline void do_nothing() {}
 
 template <class StringT>
-static inline StringT& add_leading_slash(StringT& str)
-{
-  if (str[0] != '/')
-  {
-    str.insert(str.begin(), '/');
-  }
-  return str;
-}
-
-template <class StringT>
 static inline StringT& add_trailing_slash(StringT& str)
 {
   if (str.length() >= 1)

--- a/code/memory-mgr/tests/unit_tests/test_named_objects.cpp
+++ b/code/memory-mgr/tests/unit_tests/test_named_objects.cpp
@@ -38,8 +38,8 @@ Please feel free to contact me via e-mail: shikin@users.sourceforge.net
 #include <boost/test/unit_test.hpp>
 #include <boost/mpl/list.hpp>
 
-MGR_DECLARE_SEGMENT_NAME( segmentName, "sh-seg" );
-MGR_DECLARE_SEGMENT_NAME( segmentNameTracked, "tracked-seg" );
+MGR_DECLARE_LOCAL_SEGMENT_NAME( segmentName, "sh-seg" );
+MGR_DECLARE_LOCAL_SEGMENT_NAME( segmentNameTracked, "tracked-seg" );
 
 typedef  memory_mgr::named_objects
 <

--- a/code/memory-mgr/tests/unit_tests/test_shared_segment.cpp
+++ b/code/memory-mgr/tests/unit_tests/test_shared_segment.cpp
@@ -45,7 +45,7 @@ template class memory_mgr::shared_segment< memmgr_type >;
 
 BOOST_AUTO_TEST_SUITE(test_shared_segment)
 
-	MGR_DECLARE_SEGMENT_NAME( test_segment, "test segment" );
+MGR_DECLARE_LOCAL_SEGMENT_NAME( test_segment, "test segment" );
 
 typedef memory_mgr::shared_segment< memmgr_type, MGR_SEGMENT_NAME(test_segment) > shared_mgr_type;
 typedef memory_mgr::size_tracking<shared_mgr_type > sz_shared_mgr_type;


### PR DESCRIPTION
Rework how shared segment names are defined for posix vs windows
Add ability to use Local names on Windows and pid specific for posix